### PR TITLE
Enable FTP functionality

### DIFF
--- a/roles/osx/tasks/ftp.yml
+++ b/roles/osx/tasks/ftp.yml
@@ -1,0 +1,6 @@
+# Enable the OSX default FTP server
+# As seen [here](http://superuser.com/questions/834625/how-do-i-create-an-ftp-share-on-mac-os-x-yosemite-and-access-it-from-windows-7-v)
+
+- name: Start FTP server 
+  command: launchctl load -w /System/Library/LaunchDaemons/ftp.plist 
+  sudo: yes

--- a/roles/osx/tasks/main.yml
+++ b/roles/osx/tasks/main.yml
@@ -1,6 +1,7 @@
 - include: applications.yml tags=osx
 - include: capslock_to_control.yml tags=osx,capslock
 - include: defaults.yml tags=osx,defaults
+- include: ftp.yml tags=osx,ftp
 
 # http://files.canon-europe.com/files/soft43931/software/d1343mux_m_215_drv012_cotv013_gdpv012.dmg
 # Needed on Mavericks with Xcode 4.6


### PR DESCRIPTION
We needed FTP for the Zes import tests, this adds that functionality, as described here: http://superuser.com/questions/834625/how-do-i-create-an-ftp-share-on-mac-os-x-yosemite-and-access-it-from-windows-7-v
